### PR TITLE
preserve zoom level on details open

### DIFF
--- a/nerdlets/page-view-map/index.js
+++ b/nerdlets/page-view-map/index.js
@@ -24,7 +24,7 @@ export default class PageViewMap extends React.Component {
       detailsOpen: false,
       openedFacet: null,
       mapCenter: [10.5731, -7.5898],
-      zoom: 3,
+      zoom: 3
     };
 
     this.togglePageViewDetails = this.togglePageViewDetails.bind(this);
@@ -46,11 +46,11 @@ export default class PageViewMap extends React.Component {
     }
   };
 
-  updateZoom = (zoom) => {
+  updateZoom = zoom => {
     this.setState({
       zoom: zoom
     });
-  }
+  };
 
   render() {
     const { detailsOpen, mapCenter, openedFacet } = this.state;

--- a/nerdlets/page-view-map/index.js
+++ b/nerdlets/page-view-map/index.js
@@ -23,7 +23,8 @@ export default class PageViewMap extends React.Component {
     this.state = {
       detailsOpen: false,
       openedFacet: null,
-      mapCenter: [10.5731, -7.5898]
+      mapCenter: [10.5731, -7.5898],
+      zoom: 3,
     };
 
     this.togglePageViewDetails = this.togglePageViewDetails.bind(this);
@@ -44,6 +45,12 @@ export default class PageViewMap extends React.Component {
       });
     }
   };
+
+  updateZoom = (zoom) => {
+    this.setState({
+      zoom: zoom
+    });
+  }
 
   render() {
     const { detailsOpen, mapCenter, openedFacet } = this.state;
@@ -109,8 +116,11 @@ export default class PageViewMap extends React.Component {
                                 className="containerMap"
                                 style={{ height: '99vh' }}
                                 center={mapCenter}
-                                zoom={3}
+                                zoom={this.state.zoom}
                                 zoomControl
+                                onZoomEnd={e => {
+                                  this.updateZoom(e.target._zoom);
+                                }}
                                 ref={ref => {
                                   this.mapRef = ref;
                                 }}


### PR DESCRIPTION
Related to #34 
On details open, preserve the zoom level, to prevent the map from zooming back. 