### PR TITLE
fix: Remove browser applications context

### DIFF
--- a/nerdlets/page-view-map/nr1.json
+++ b/nerdlets/page-view-map/nr1.json
@@ -2,13 +2,5 @@
     "schemaType": "NERDLET",
     "id": "page-view-map",
     "description": "Page View Map",
-    "displayName": "Page View Map",
-    "context": {
-        "entities": [
-            {
-                "domain": "BROWSER",
-                "type": "APPLICATION"
-            }
-        ]
-    }
+    "displayName": "Page View Map"
 }


### PR DESCRIPTION
With this context object in place, this app appears under "More views" in the main nav for all browser applications, and some users have stumbled across this view and run into errors.

Because this view in essence offers the same capabilities as the "Monitor" > "Filterable geos" experience, we would like to remove this view from the nav to guide users towards that officially supported experience.